### PR TITLE
Fix: Update Fire icon to Flame in UserProfilePage

### DIFF
--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -8,7 +8,7 @@ import {
   BookOpen, 
   Clock, 
   Award,
-  Fire,
+  Flame,
   Settings,
   LogOut,
   Edit3,
@@ -104,7 +104,7 @@ const UserProfilePage: React.FC = () => {
     {
       title: 'Streak Master',
       description: 'Maintained a 7-day streak',
-      icon: Fire,
+      icon: Flame,
       earned: (userProgress?.current_streak || 0) >= 7,
       color: 'text-orange-400',
       bgColor: 'bg-orange-500/10',


### PR DESCRIPTION
The `Fire` icon from `lucide-react` was causing a build failure as it was not found in the library exports.

This commit replaces the `Fire` icon with the `Flame` icon, which is the correct name for the icon in the version of `lucide-react` being used.

The build has been verified to complete successfully after this change.